### PR TITLE
remove invalid ubuntu check

### DIFF
--- a/Formula/sui.rb
+++ b/Formula/sui.rb
@@ -24,7 +24,7 @@ class Sui < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    if Hardware::CPU.is_64_bit?
       url "https://sui-releases.s3-accelerate.amazonaws.com/releases/sui-mainnet-v1.16.2-ubuntu-x86_64.tgz"
       sha256 "cc525fe55408a71b42a1777cd0ce6c8e58d4f1be159f2e7290d1d98e71a1e1a2"
 

--- a/template/sui.rb.j2
+++ b/template/sui.rb.j2
@@ -24,7 +24,7 @@ class Sui < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    if Hardware::CPU.is_64_bit?
       url "https://sui-releases.s3-accelerate.amazonaws.com/releases/sui-mainnet-v{{ version }}-ubuntu-x86_64.tgz"
       sha256 "{{ linux_sha256 }}"
 


### PR DESCRIPTION
This hardware check doesn't make a lot of sense, limiting it to just ensuring the cpu is 64 bit

fixes https://github.com/MystenLabs/homebrew-tap/issues/3