### PR TITLE
deprecate mystenlabs/tap/sui

### DIFF
--- a/Formula/sui.rb
+++ b/Formula/sui.rb
@@ -4,6 +4,8 @@ class Sui < Formula
   version "1.17.3"
   license "Apache-2.0"
 
+  deprecate! date: "2024-02-05", because: "migrated to homebrew-core, untap and install via homebrew core: `brew untap mystenlabs/tap && brew install sui`"
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://sui-releases.s3-accelerate.amazonaws.com/releases/sui-mainnet-v1.17.3-macos-arm64.tgz"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ See homebrew's docs for more information on [taps](https://docs.brew.sh/Taps)
 
 ## Usage
 
-You can use this tap to install the sui cli, eg:
+You can use this tap to ~install the sui cli~ sui cli has been added to homebrew-core, this tap is currently unused.
 
 ```sh
 brew tap mystenlabs/tap
-brew install mystenlabs/tap/sui
 ```

--- a/template/sui.rb.j2
+++ b/template/sui.rb.j2
@@ -4,6 +4,8 @@ class Sui < Formula
   version "{{ version }}"
   license "Apache-2.0"
 
+  deprecate! date: "2024-02-05", because: "migrated to homebrew-core, untap and install via homebrew core: `brew untap mystenlabs/tap && brew install sui`"
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://sui-releases.s3-accelerate.amazonaws.com/releases/sui-testnet-v{{ version }}-macos-arm64.tgz"


### PR DESCRIPTION
Since sui is now a homebrew core formula, deprecate the formula in our custom tap. https://github.com/Homebrew/homebrew-core/pull/161424